### PR TITLE
User can Remove a Food From a Meal

### DIFF
--- a/controllers/api/v1/meals_controller.js
+++ b/controllers/api/v1/meals_controller.js
@@ -76,8 +76,41 @@ var addFood = async function(req, res) {
   }
 }
 
+var removeFood = async function(req, res) {
+  let food = await Food.findOne({
+    where: {
+      id: req.params.food_id
+    }
+  })
+  let meal = await Meal.findOne({
+    where: {
+      id: req.params.id
+    }
+  })
+  if (meal && food) {
+    MealFoods.destroy({
+      where:{
+        foodId: food.dataValues.id,
+        mealId: meal.dataValues.id
+      }
+    })
+    .then(() => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(204).send();
+    })
+    .catch(error => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(500).send({ error });
+    })
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(404).send();
+  }
+}
+
 module.exports = {
   index: index,
   show: show,
-  addFood: addFood
+  addFood: addFood,
+  removeFood: removeFood
 }

--- a/routes/api/v1/meals/index.js
+++ b/routes/api/v1/meals/index.js
@@ -4,5 +4,6 @@ var mealsController = require('../../../../controllers/api/v1/meals_controller')
 router.get('/', mealsController.index)
 router.get('/:id/foods', mealsController.show)
 router.post('/:id/foods/:food_id', mealsController.addFood)
+router.delete('/:id/foods/:food_id', mealsController.removeFood)
 
 module.exports = router;

--- a/test/meal_test.js
+++ b/test/meal_test.js
@@ -171,4 +171,58 @@ describe("Meals", () => {
       });
     });
   });
+  describe("Delete /api/v1/meals/:id/foods/:food_id", () => {
+    it("should delete a food from a meal", (done) => {
+      chai.request(app)
+      .delete('/api/v1/meals/8010/foods/9012')
+      .end((err, res) => {
+        res.should.have.status(204);
+        Meal.findOne({
+          where: {
+            id: 8010
+          },
+          include: [
+            {
+              model: Food,
+              as: 'foods'
+            }
+          ]
+        })
+        .then(meal => {
+          meal.foods.length.should.equal(2)
+        })
+        Food.findOne({
+          where: {
+            id: 9012
+          },
+          include: [
+            {
+              model: Meal,
+              as: 'meals'
+            }
+          ]
+        })
+        .then(food => {
+          food.meals.length.should.equal(0)
+        })
+        done();
+      });
+    });
+    it("should return 404 if mealId does not exist", (done) => {
+      chai.request(app)
+      .delete('/api/v1/meals/8010/foods/100000010')
+      .end((err, res) => {
+        res.should.have.status(404);
+        done();
+      });
+    });
+    it("should return 404 if foodId does not exist", (done) => {
+      chai.request(app)
+      .delete('/api/v1/meals/100000010/foods/9012')
+      .end((err, res) => {
+        res.should.have.status(404);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Co-Authored-By: Vince Carollo <vincecarollo@gmail.com>

## What functionality does this accomplish?
closes #13
​
**Description:**
​This PR adds a path to delete the association between a food and a meal.
- Adds tests for happy and sad paths.
- Sends a 404 if either meal or food does not exist. 
​
## What did you struggle on to complete?
​Largely duplicated post functionality to add meal
​
​
## Current Test Suite:
### Test Coverage Percentage: x%
- [ ] No Tests have been changed
- [ ] Some Tests have been changed
- [x] All of the Tests have been changed(Please describe what in the world happened):
​
## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

