### PR TITLE
Add tests for limit on foods index

### DIFF
--- a/controllers/api/v1/foods_controller.js
+++ b/controllers/api/v1/foods_controller.js
@@ -2,7 +2,8 @@ var Food = require('../../../models').Food;
 var FoodPresenter = require('../../../pojos/food_presenter.js');
 
 var index = function (req, res) {
-  Food.findAll()
+  Food.findAll({limit: req.query.limit}
+)
     .then(food_info => {
       res.setHeader("Content-Type", "application/json");
       res.setHeader("Access-Control-Allow-Methods", 'GET, POST');

--- a/test/food_test.js
+++ b/test/food_test.js
@@ -58,7 +58,7 @@ describe("Foods", () => {
     describe("GET /api/v1/foods?limit=2", () => {
         it("should get 2 foods record", (done) => {
           chai.request(app)
-          .get('/api/v1/foods')
+          .get('/api/v1/foods?limit=2')
           .end((err, res) => {
             res.should.have.status(200);
             res.body[0].should.be.a('object');
@@ -70,7 +70,7 @@ describe("Foods", () => {
     describe("GET /api/v1/foods?limit=5", () => {
         it("should get all foods record if limit greater than food count", (done) => {
           chai.request(app)
-          .get('/api/v1/foods')
+          .get('/api/v1/foods?limit=5')
           .end((err, res) => {
             res.should.have.status(200);
             res.body[0].should.be.a('object');

--- a/test/food_test.js
+++ b/test/food_test.js
@@ -22,6 +22,11 @@ describe("Foods", () => {
         id: 9010,
         name: 'salad',
         calories: 100
+      },
+      {
+        id: 9011,
+        name: 'nachos',
+        calories: 200
       }
     ])
   })
@@ -44,11 +49,36 @@ describe("Foods", () => {
           res.body[0].calories.should.equal(600)
           res.body[0].should.not.have.property('createdAt')
           res.body[0].should.not.have.property('updatedAt')
-          res.body.should.have.lengthOf(2);
+          res.body.should.have.lengthOf(3);
           done();
         });
       });
     });
+
+    describe("GET /api/v1/foods?limit=2", () => {
+        it("should get 2 foods record", (done) => {
+          chai.request(app)
+          .get('/api/v1/foods')
+          .end((err, res) => {
+            res.should.have.status(200);
+            res.body[0].should.be.a('object');
+            res.body.should.have.lengthOf(2);
+            done();
+          });
+        });
+      });
+    describe("GET /api/v1/foods?limit=5", () => {
+        it("should get all foods record if limit greater than food count", (done) => {
+          chai.request(app)
+          .get('/api/v1/foods')
+          .end((err, res) => {
+            res.should.have.status(200);
+            res.body[0].should.be.a('object');
+            res.body.should.have.lengthOf(3);
+            done();
+          });
+        });
+      });
 
     describe("GET /api/v1/foods/:id", () => {
       it("should get a single food record", (done) => {


### PR DESCRIPTION
## What functionality does this accomplish?
closes #49
​
**Description:**
​Adds limit to food show page allowing user to query get/api/v1/foods/?limit=3 and only return 3 foods
Change some foods tests to test this functionality.
​
## Current Test Suite:
### Test Coverage Percentage: 88.6%
- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):
​
## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):
​
## Helpful Resources:
https://sequelize.org/master/manual/querying.html#pagination---limiting